### PR TITLE
Make resize message configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ interface GuidedTour {
     completeCallback?: () => void;
     /** Minimum size of screen in pixels before the tour is run, if the tour is resized below this value the user will be told to resize */
     minimumScreenSize?: number;
+    /** Dialog shown if the window width is smaller than the defined minimum screen size. */
+    resizeDialog?: {
+        /** Resize dialog title text */
+        title?: string;
+        /** Resize dialog text */
+        content: string;
+    }
 }
 ```
 

--- a/projects/ngx-guided-tour/src/lib/guided-tour.constants.ts
+++ b/projects/ngx-guided-tour/src/lib/guided-tour.constants.ts
@@ -35,6 +35,13 @@ export interface GuidedTour {
     completeCallback?: () => void;
     /** Minimum size of screen in pixels before the tour is run, if the tour is resized below this value the user will be told to resize */
     minimumScreenSize?: number;
+    /** Dialog shown if the window width is smaller than the defined minimum screen size. */
+    resizeDialog?: {
+        /** Resize dialog title text */
+        title?: string;
+        /** Resize dialog text */
+        content: string;
+    }
     /**
      * Prevents the tour from advancing by clicking the backdrop.
      * This should only be set if you are completely sure your tour is displaying correctly on all screen sizes otherwise a user can get stuck.

--- a/projects/ngx-guided-tour/src/lib/guided-tour.service.ts
+++ b/projects/ngx-guided-tour/src/lib/guided-tour.service.ts
@@ -27,10 +27,12 @@ export class GuidedTourService {
             if (this._currentTour && this._currentTourStepIndex > -1) {
                 if (this._currentTour.minimumScreenSize && this._currentTour.minimumScreenSize >= window.innerWidth) {
                     this._onResizeMessage = true;
-                    this._guidedTourCurrentStepSubject.next({
+                    const dialog = this._currentTour.resizeDialog || {
                         title: 'Please resize',
                         content: 'You have resized the tour to a size that is too small to continue. Please resize the browser to a larger size to continue the tour or close the tour.'
-                    });
+                    };
+
+                    this._guidedTourCurrentStepSubject.next(dialog);
                 } else {
                     this._onResizeMessage = false;
                     this._guidedTourCurrentStepSubject.next(this.getPreparedTourStep(this._currentTourStepIndex));


### PR DESCRIPTION
PR for issue #27 

Added a new property to the guided tour interface. This allows to configure the resize message (title + text). The property optional and a default text will be shown if it's not provided (it's backward compatible).

Please review it and let me know if you would like to change anything.