### PR TITLE
fix(angular-version): change import to avoid angular 9 warnings

### DIFF
--- a/projects/ngx-guided-tour/src/lib/guided-tour.module.ts
+++ b/projects/ngx-guided-tour/src/lib/guided-tour.module.ts
@@ -1,35 +1,21 @@
 import { GuidedTourService } from './guided-tour.service';
 import { GuidedTourComponent } from './guided-tour.component';
-import { NgModule, ErrorHandler } from '@angular/core';
+import { NgModule, ErrorHandler, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ModuleWithProviders } from '@angular/compiler/src/core';
-import { WindowRefService } from "./windowref.service";
+import { WindowRefService } from './windowref.service';
 
 @NgModule({
-    declarations: [
-        GuidedTourComponent
-    ],
-    imports: [
-        CommonModule
-    ],
-    providers: [
-        WindowRefService
-    ],
-    exports: [
-        GuidedTourComponent
-    ],
-    entryComponents: [
-        GuidedTourComponent
-    ]
+  declarations: [GuidedTourComponent],
+  imports: [CommonModule],
+  providers: [WindowRefService],
+  exports: [GuidedTourComponent],
+  entryComponents: [GuidedTourComponent],
 })
 export class GuidedTourModule {
-    public static forRoot(): ModuleWithProviders {
-        return {
-            ngModule: GuidedTourModule,
-            providers: [
-                ErrorHandler,
-                GuidedTourService
-            ]
-        };
-    }
+  public static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: GuidedTourModule,
+      providers: [ErrorHandler, GuidedTourService],
+    };
+  }
 }

--- a/projects/ngx-guided-tour/src/lib/ngx-guided-tour.module.ts
+++ b/projects/ngx-guided-tour/src/lib/ngx-guided-tour.module.ts
@@ -1,8 +1,7 @@
 import { GuidedTourService } from './guided-tour.service';
 import { GuidedTourComponent } from './guided-tour.component';
-import { NgModule, ErrorHandler } from '@angular/core';
+import { NgModule, ErrorHandler, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ModuleWithProviders } from '@angular/compiler/src/core';
 
 @NgModule({
     declarations: [


### PR DESCRIPTION
remove deep imports, this commit will remove the compiler warnings displayed when using the ngx-guided-tour with Angular 9

fix #51