### PR TITLE
Add type to ModuleWithProviders for Angular 10 compatibility

### DIFF
--- a/projects/ngx-guided-tour/src/lib/ngx-guided-tour.module.ts
+++ b/projects/ngx-guided-tour/src/lib/ngx-guided-tour.module.ts
@@ -18,7 +18,7 @@ import { CommonModule } from '@angular/common';
     ]
 })
 export class NgxGuidedTourModule {
-    public static forRoot(): ModuleWithProviders {
+    public static forRoot(): ModuleWithProviders<NgxGuidedTourModule> {
         return {
             ngModule: NgxGuidedTourModule,
             providers: [


### PR DESCRIPTION
Hi,

Angular 10 requires that a type must be added to forRoot method definition so ModuleWithProviders becomes `ModuleWithProviders<NgxGuidedTourModule>`.

I have forked the library and made the change.

Coud you please review this change and if considered OK publish a new version of the library?

Thank you very much and congrats for this fantastic library.

Best regards.