### PR TITLE
Use lodash-es instead lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9891,6 +9891,11 @@
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
             "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         },
+        "lodash-es": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+        },
         "lodash.clonedeep": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "@angular/router": "8.2.14",
         "bootstrap": "4.3.1",
         "core-js": "2.6.6",
+        "lodash-es": "4.17.21",
         "node-sass": "4.13.1",
         "rxjs": "6.3.3",
         "tslib": "1.9.3",

--- a/projects/ngx-guided-tour/src/lib/guided-tour.service.ts
+++ b/projects/ngx-guided-tour/src/lib/guided-tour.service.ts
@@ -2,7 +2,7 @@ import { debounceTime } from 'rxjs/operators';
 import { ErrorHandler, Inject, Injectable } from '@angular/core';
 import { Observable, Subject, fromEvent } from 'rxjs';
 import { GuidedTour, TourStep, Orientation, OrientationConfiguration } from './guided-tour.constants';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash-es/cloneDeep';
 import { DOCUMENT } from "@angular/common";
 import { WindowRefService } from "./windowref.service";
 


### PR DESCRIPTION
This will reduce size of vendor.js from 4.3 to 3.9mb

