### PR TITLE
fix lodash import

### DIFF
--- a/projects/ngx-guided-tour/src/lib/guided-tour.service.ts
+++ b/projects/ngx-guided-tour/src/lib/guided-tour.service.ts
@@ -2,7 +2,7 @@ import { debounceTime } from 'rxjs/operators';
 import { ErrorHandler, Inject, Injectable } from '@angular/core';
 import { Observable, Subject, fromEvent } from 'rxjs';
 import { GuidedTour, TourStep, Orientation, OrientationConfiguration } from './guided-tour.constants';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 import { DOCUMENT } from "@angular/common";
 import { WindowRefService } from "./windowref.service";
 


### PR DESCRIPTION
Import single `cloneDeep` will reduce size of vendor.js from 4.3 to 3.9mb